### PR TITLE
Add forward ref, and expose draw fn

### DIFF
--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -54,4 +54,5 @@ export interface MakeCanvasReturn<R, T> {
   useScribbleContext: () => ScribbleContext<T, R>
   useDraw: (drawFn: DrawFN<T, R>, deps?: unknown[]) => void
   Canvas: React.FC<CanvasProps<T, R>>
+  draw: DrawLoopFN<T, R>
 }


### PR DESCRIPTION
## Description

There before was no way draw the canvas without turning on the render loop. This make the draw accessible via the ref, and export.
